### PR TITLE
Force QT to use X11

### DIFF
--- a/com.google.EarthPro.yaml
+++ b/com.google.EarthPro.yaml
@@ -95,4 +95,5 @@ modules:
         dest-filename: earth-runner
         commands:
           - export LD_LIBRARY_PATH="/app/lib:/app/lib64:$LD_LIBRARY_PATH"
+          - export QT_QPA_PLATFORM=xcb
           - exec /app/extra/google/earth/pro/googleearth $@


### PR DESCRIPTION
Surprisingly this resolves my problems on a Wayland distro, I think because the runtime is set up to translate X11 to Wayland. Possibly related to #21 and/or #22.

----

This pull request introduces a minor update to the `com.google.EarthPro.yaml` module configuration. The change ensures that the correct Qt platform plugin is specified for the application.

* Added `export QT_QPA_PLATFORM=xcb` to the command list to explicitly set the Qt platform to X11, improving compatibility on Linux systems.